### PR TITLE
Add Windows compatibility

### DIFF
--- a/arduino/USBMultiMIDI.cpp
+++ b/arduino/USBMultiMIDI.cpp
@@ -127,8 +127,8 @@ typedef struct	// MIDI OUT Jack Descriptor (USB MIDI Spec. 1.0: Table 6-4)
 	uint8_t bJackType;			// EMBEDDED or EXTERNAL
 	uint8_t bJackID;			// Constant uniquely identifying the MIDI OUT Jack within the USB-MIDI function.
 	uint8_t bNrInputPins;		// Number of Input Pins of this MIDI OUT Jack: p
-//	uint8_t baSourceID[1];		// ID of the Entity to which the last Input Pin of this MIDI OUT Jack is connected.
-//	uint8_t baSourcePin[1];		// Output Pin number of the Entity to which the last Input Pin of this MIDI OUT Jack is connected.
+	uint8_t baSourceID[1];		// ID of the Entity to which the last Input Pin of this MIDI OUT Jack is connected.
+	uint8_t baSourcePin[1];		// Output Pin number of the Entity to which the last Input Pin of this MIDI OUT Jack is connected.
 	uint8_t iJack;				// Index of a string descriptor, describing the MIDI OUT Jack.
 } MIDIJackOutDescriptor;
 
@@ -181,7 +181,7 @@ typedef struct	// Class-specific MS Bulk Data Endpoint Descriptor [for MIDI Jack
 #define D_MIDI_INJACK(jackProp, jackID) \
 	{ 0x06, MS_CS_INTERFACE, MS_IDS_IN_JACK, jackProp, jackID, 0 }
 #define D_MIDI_OUTJACK(jackProp, jackID) \
-	{ 0x07, MS_CS_INTERFACE, MS_IDS_OUT_JACK, jackProp, jackID, 0, 0 }
+	{ 0x09, MS_CS_INTERFACE, MS_IDS_OUT_JACK, jackProp, jackID, 1, 1, 1, 0 }
 #define D_MIDI_JACK_EP(addr, attr, packetSize) \
 	{ 0x09, 5, addr, attr, packetSize, 0, 0, 0 }
 #define D_MIDI_AC_JACK_EP() \


### PR DESCRIPTION
After a whole lot of testings, and based on the official MIDIUSB project that actually works fine, I was finally able to make my Arduino Leonard detected by Windows even after a reboot.

I don't know what baSourceID and baSourcePin should really be, looks like being just 1 works fine (not 0 though). My MAX3232 has shipped but not arrived already so I can't test it on my NS5R (and not even with other synths), so I'd be glad if someone else could try it. The debugging prints makes it look like it works though.